### PR TITLE
Fix throwing weapon effects

### DIFF
--- a/src/main/java/com/chaosbuffalo/spartanfire/SpartanFire.java
+++ b/src/main/java/com/chaosbuffalo/spartanfire/SpartanFire.java
@@ -6,8 +6,6 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 @Mod(modid = SpartanFire.MODID, name = SpartanFire.NAME, version = SpartanFire.VERSION,
         dependencies="required-after:iceandfire;required-after:spartanweaponry@[1.6.0,);required-after:llibrary@[1.7.19,)")
@@ -16,8 +14,6 @@ public class SpartanFire
     public static final String MODID = "spartanfire";
     public static final String NAME = "Spartan Fire";
     public static final String VERSION = "1.3.0";
-
-    public static final Logger logger = LogManager.getLogger(NAME);
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event)

--- a/src/main/java/com/chaosbuffalo/spartanfire/integrations/RLCombatCompat.java
+++ b/src/main/java/com/chaosbuffalo/spartanfire/integrations/RLCombatCompat.java
@@ -3,6 +3,7 @@ package com.chaosbuffalo.spartanfire.integrations;
 import bettercombat.mod.event.RLCombatModifyDamageEvent;
 import com.oblivioussp.spartanweaponry.api.weaponproperty.WeaponProperty;
 import com.oblivioussp.spartanweaponry.item.ItemSwordBase;
+import com.oblivioussp.spartanweaponry.item.ItemThrowingWeapon;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -19,10 +20,16 @@ public class RLCombatCompat {
         Entity target = event.getTarget();
         if (player == null || !(target instanceof EntityLivingBase) || event.getStack().isEmpty()) return;
         Item item = event.getStack().getItem();
-        if (item instanceof ItemSwordBase) {
+        if (item instanceof ItemSwordBase || item instanceof ItemThrowingWeapon) {
             float mod = 0F;
 
-            List<WeaponProperty> properties = ((ItemSwordBase) item).getAllWeaponProperties();
+            List<WeaponProperty> properties;
+            if (item instanceof ItemSwordBase) {
+                properties = ((ItemSwordBase) item).getAllWeaponProperties();
+            } else {
+                properties = ((ItemThrowingWeapon) item).getAllWeaponProperties();
+            }
+
             for (WeaponProperty property : properties) {
                 if (property instanceof SpartanFireWeaponProperty) {
                     mod += ((SpartanFireWeaponProperty) property).getHitEffectModifier((EntityLivingBase)target, player);

--- a/src/main/java/com/chaosbuffalo/spartanfire/integrations/SpartanFireWeaponProperty.java
+++ b/src/main/java/com/chaosbuffalo/spartanfire/integrations/SpartanFireWeaponProperty.java
@@ -12,7 +12,7 @@ public abstract class SpartanFireWeaponProperty extends WeaponPropertyWithCallba
     }
 
     public float modifyDamageDealt(ToolMaterialEx material, float baseDamage, float initialDamage, DamageSource source, EntityLivingBase attacker, EntityLivingBase target) {
-        if (CompatLoadUtil.isRLCombatLoaded()) return baseDamage;
+        if (!source.isProjectile() && CompatLoadUtil.isRLCombatLoaded()) return baseDamage;
         return baseDamage + getHitEffectModifier(target, attacker);
     }
 


### PR DESCRIPTION
The throwing weapons do not trigger modifyAttackDamagePre within RLCombat - when thrown as projectiles.